### PR TITLE
Resize of Move Tiled or Maximized Windows

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -179,7 +179,12 @@ class Extension {
 
     MoveResize(winid, x, y, width, height) {
         let win = this._get_window_by_wid(winid);
+
         if (win) {
+            if (win.meta_window.maximized_horizontally || win.meta_window.maximized_vertically) {
+                win.meta_window.unmaximize(3);
+            }
+
             win.meta_window.move_resize_frame(0, x, y, width, height);
         } else {
             throw new Error('Not found');
@@ -189,6 +194,9 @@ class Extension {
     Resize(winid, width, height) {
         let win = this._get_window_by_wid(winid);
         if (win) {
+            if (win.meta_window.maximized_horizontally || win.meta_window.maximized_vertically) {
+                win.meta_window.unmaximize(3);
+            }
             win.meta_window.move_resize_frame(0, win.get_x(), win.get_y(), width, height);
         } else {
             throw new Error('Not found');
@@ -198,6 +206,9 @@ class Extension {
     Move(winid, x, y) {
         let win = this._get_window_by_wid(winid).meta_window;
         if (win) {
+            if (win.meta_window.maximized_horizontally || win.meta_window.maximized_vertically) {
+                win.meta_window.unmaximize(3);
+            }
             win.move_frame(0, x, y);
         } else {
             throw new Error('Not found');


### PR DESCRIPTION
There is an issue which gnome calls an expected behavior.

https://gitlab.gnome.org/GNOME/mutter/-/issues/2407#note_1539160

> "Tiled" is treated as a window state like "maximized", so the window is positioned and sized automatically until it becomes unconstrained again.

So basically we can not move or resize a maximized or tiled window.

This patch is a fix to that. It is sort of a hack.

People have written classes to solve this [problem](https://github.com/Leleat/Tiling-Assistant/issues/173).

https://github.com/Leleat/Tiling-Assistant/blob/main/tiling-assistant%40leleat-on-github/src/extension/resizeHandler.js
https://github.com/Leleat/Tiling-Assistant/blob/main/tiling-assistant%40leleat-on-github/src/extension/moveHandler.js

being a newbie, i just unmaximized (which is also untile) the window before moving or resizing it.
