### PR TITLE
Port to gnome shell 45

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,10 +16,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-/* exported init */
-const {
-  Gio
-} = imports.gi;
+import Gio from 'gi://Gio';
 
 const MR_DBUS_IFACE = `
 <node>
@@ -82,7 +79,7 @@ const MR_DBUS_IFACE = `
 </node>`;
 
 
-class Extension {
+export default class Extension {
   enable() {
     this._dbus = Gio.DBusExportedObject.wrapJSObject(MR_DBUS_IFACE, this);
     this._dbus.export(Gio.DBus.session, '/org/gnome/Shell/Extensions/Windows');
@@ -284,8 +281,4 @@ class Extension {
       throw new Error('Not found');
     }
   }
-}
-
-function init() {
-  return new Extension();
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,11 +3,7 @@
   "description": "Adds dbus calls which can return list of windows, move, resize, close them etc",
   "uuid": "window-calls@domandoman.xyz",
   "shell-version": [
-    "40",
-    "41",
-    "42",
-    "43",
-    "44"
+    "45"
   ],
   "version": 1.9,
   "url": "https://github.com/ickyicky/window-calls"


### PR DESCRIPTION
This add support for gnome shell 45. Unfortunately it's not possible to do this in a backwards compatible way due to the new imports, hence this also throws away support for older shell versions.