### PR TITLE
Added useful title property into windows list.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -141,7 +141,7 @@ export default class Extension {
     const workspaceManager = global.workspace_manager;
 
     const props = {
-      get: ['wm_class', 'wm_class_instance', 'pid', 'id', 'frame_type', 'window_type', 'width', 'height', 'x', 'y'],
+      get: ['wm_class', 'wm_class_instance', 'title', 'pid', 'id', 'frame_type', 'window_type', 'width', 'height', 'x', 'y'],
       has: ['focus'],
       // custom: new Map([])
     };


### PR DESCRIPTION
We can use like this:

```sh
 ╰─ $ 130  gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell/Extensions/Windows --method org.gnome.Shell.Extensions.Windows.List |gdbus_json | jq -e -c '[.[] | select (.frame_type == 0 and .window_type == 0) | {id: .id,wm_class: .wm_class,focus: .focus,pid: .pid, title: .title}]'|jq
[
  {
    "id": 677496530,
    "wm_class": "fsearch",
    "focus": false,
    "pid": 1731,
    "title": "FSearch"
  },
  {
    "id": 677496533,
    "wm_class": "org.telegram.desktop",
    "focus": false,
    "pid": 1650,
    "title": "Telegram"
  },
  {
    "id": 677496535,
    "wm_class": "QQ",
    "focus": false,
    "pid": 1667,
    "title": "QQ"
  },
  {
    "id": 677496538,
    "wm_class": "emacs",
    "focus": false,
    "pid": 4887,
    "title": "*Warnings* - Emacs 29.1.90"
  },
  {
    "id": 677496540,
    "wm_class": "firefox",
    "focus": false,
    "pid": 7142,
    "title": "Comparing ickyicky:main...zw963:main · ickyicky/window-calls — Mozilla Firefox"
  },
  {
    "id": 677496534,
    "wm_class": "konsole",
    "focus": true,
    "pid": 1744,
    "title": "/home/zw963/Git/window-calls — Konsole"
  }
]
```