### PR TITLE
Switch to workspace of activated window before raising it

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -287,9 +287,14 @@ export default class Extension {
   }
 
   Activate(winid) {
-    let win = this._get_window_by_wid(winid).meta_window;
+    const win = this._get_window_by_wid(winid).meta_window;
     if (win) {
-      win.activate(0);
+      const workspace = win.get_workspace();
+      if (workspace) {
+        workspace.activate_with_focus(win, 0);
+      } else {
+        win.activate(0);
+      }
     } else {
       throw new Error('Not found');
     }


### PR DESCRIPTION
Activating a window by its ID does not bring you to the workspace that it occupies, forcing you to click on a notification if you are not already in the workspace that it occupies to bring yourself over to it. This PR simply switches to the active workspace of the window before raising it, saving you a click.