### PR TITLE
feat: replaced win.kill with win.delete for graceful windows closing

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -303,8 +303,8 @@ export default class Extension {
   Close(winid) {
     let win = this._get_window_by_wid(winid).meta_window;
     if (win) {
-      win.kill();
-      // win.delete(Math.floor(Date.now() / 1000));
+      win.delete(global.get_current_time())
+      // win.kill();
     } else {
       throw new Error('Not found');
     }


### PR DESCRIPTION
Hi!

I would like to propose moving away from `win.kill` as this function forcefully terminates the client process associated with the window. Many applications do not like it and go to the safe mode during the next run. 
`win.delete()` requests a graceful close, equivalent to clicking the 'X' button or sending the standard close signal, and is the preferred way to close the application.

Thanks,
Alex