### PR TITLE
GNOME 49 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "version": 1.13,
   "url": "https://github.com/ickyicky/window-calls"


### PR DESCRIPTION
GNOME 49 is out, this extension still works!