### PR TITLE
Add method to make a window fullscreen

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -115,7 +115,7 @@ gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell/Exten
 
 ### Maximizing, minimizing, activating, closing
 
-Ther are 6 methods providing such functionality:
+Ther are 7 methods providing such functionality:
 
 1. `Maximize`
 2. `Minimize`
@@ -123,8 +123,9 @@ Ther are 6 methods providing such functionality:
 4. `Unminimize`
 5. `Activate`
 6. `Close`
+7. `MakeFullscreen`
 
-Each takes only one parameter, winid.
+Each takes only one parameter, `winid`.
 
 ## Using With `jq`
 

--- a/extension.js
+++ b/extension.js
@@ -61,6 +61,9 @@ const MR_DBUS_IFACE = `
          <arg type="i" direction="in" name="x" />
          <arg type="i" direction="in" name="y" />
       </method>
+      <method name="MakeFullscreen">
+         <arg type="u" direction="in" name="winid" />
+      </method>
       <method name="Maximize">
          <arg type="u" direction="in" name="winid" />
       </method>
@@ -261,6 +264,15 @@ export default class Extension {
         win.meta_window.unmaximize(3);
       }
       win.meta_window.move_frame(1, x, y);
+    } else {
+      throw new Error('Not found');
+    }
+  }
+
+  MakeFullscreen(winid) {
+    let win = this._get_window_by_wid(winid).meta_window;
+    if (win) {
+      win.make_fullscreen();
     } else {
       throw new Error('Not found');
     }


### PR DESCRIPTION
Useful for scripting video players!  

Trivial change once I figured out what the method was in mutter.  Tested with gnome-shell 50.0