### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,.gitignore,.gitattributes,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git,.gitignore,.gitattributes,.codespellrc
+skip = .git,.git-meta,.gitignore,.gitattributes,.codespellrc
 check-hidden = true
 # ignore-regex = 
 # ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/Readme.md
+++ b/Readme.md
@@ -115,7 +115,7 @@ gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell/Exten
 
 ### Maximizing, minimizing, activating, closing
 
-Ther are 7 methods providing such functionality:
+There are 7 methods providing such functionality:
 
 1. `Maximize`
 2. `Minimize`

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Window Calls
 
-This extension allows you to list current windows with some of their properties from command line, super usefull for Wayland to get current focused window.
+This extension allows you to list current windows with some of their properties from command line, super useful for Wayland to get current focused window.
 
 Also, it allows you to move given window to different workspace.
 
@@ -99,7 +99,7 @@ Example result of calling `Details`:
 
 ### Resizing and moving
 
-Resizing and moving can be done either together or separetely. There are 3 methods providing this functionality:
+Resizing and moving can be done either together or separately. There are 3 methods providing this functionality:
 
 1. `Resize` which takes 3 parameters: winid width height
 2. `MoveResize` which takes 3 parameters: winid x y width height


### PR DESCRIPTION
Add codespell configuration and fix existing typos.

More about codespell: https://github.com/codespell-project/codespell

I personally introduced it to over a hundred of projects already mostly with a positive feedback
(see the ["improveit-dashboard"](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)).

CI workflow has `permissions` set only to `read` so should be safe.

## Changes

### Configuration & Infrastructure
- Added `.codespellrc` with sensible defaults (skips `.git`, `.git-meta`,
  `.gitignore`, `.gitattributes`, `.codespellrc`; `check-hidden = true`).
- Added `.github/workflows/codespell.yml` to run codespell on push and PRs
  to `main` (using pinned `codespell-project/actions-codespell@v2.2`).

### Typo Fixes

**Ambiguous typo fixed manually** (context required):
- `Readme.md:118`: `Ther are 7 methods` → `There are 7 methods`
  (codespell suggested `There, Their, The, Other`; sentence context
  makes "There" unambiguous).

**Non-ambiguous typos fixed via `codespell -w`**:
- `Readme.md:3`: `usefull` → `useful`
- `Readme.md:102`: `separetely` → `separately`

### Historical Context
There is at least one prior commit (a9d22e7 "typo: `ceratin` ? certain")
addressing a typo manually — automated checking helps prevent these from
sneaking in.

## Testing

Codespell passes with zero errors on this branch.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
